### PR TITLE
Update Coordinator.swift

### DIFF
--- a/Sources/SKRools/Coordinator/Coordinator.swift
+++ b/Sources/SKRools/Coordinator/Coordinator.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol Coordinator: AnyObject {
+public protocol Coordinator: class {
     var childCoordinators: [Coordinator] { get set }
     var navigationController: UINavigationController { get set }
 


### PR DESCRIPTION
I don't see the purpose of constraining `Coordinator`  to `AnyObject`, because it makes you inherit from NSObject which I think is unnecessary